### PR TITLE
feat: Added foreground and transparent for BgColor

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -8,10 +8,19 @@ export default function Page() {
           data={`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus faucibus in augue a porttitor. Donec tincidunt, sapien nec ultricies finibus, nulla metus dictum sem, non scelerisque sapien lacus quis libero. Donec blandit sit amet ipsum a molestie. Morbi sit amet tortor libero. Vivamus in dolor elit. Praesent ultrices sem efficitur lorem aliquam, nec placerat mauris hendrerit.`}
           shape='square'
         />
-        <QRX data='https://github.com/devtrice' shape='circle' eyeBall='circle' />
-        <QRX data='https://github.com/devtrice' shape='diamond' />
+        <QRX data='https://github.com/devtrice' shape='circle' eyeBall='circle' foregroundColor='#FF0000' />
+        <QRX data='https://github.com/devtrice' shape='circle' eyeBall='circle' foregroundColor='rgb(0, 94, 255)' />
+        <QRX data='https://github.com/devtrice' shape='circle' eyeBall='circle' foregroundColor='rgb(0, 94, 255)' />
+        <div
+          style={{
+            background: 'red',
+          }}
+        >
+          <QRX data='https://github.com/devtrice' shape='diamond' />
+        </div>
         <QRX data='https://github.com/devtrice' shape='triangle' />
-        <QRX data='https://github.com/devtrice' shape='heart' eyeBall='circle' />
+        <QRX data='https://github.com/devtrice' shape='heart' eyeBall='circle' multiplePahts />
+        <QRX data='https://github.com/devtrice' shape='heart' eyeBall='circle' multiplePahts />
       </div>
     </main>
   )

--- a/packages/react/index.tsx
+++ b/packages/react/index.tsx
@@ -1,21 +1,45 @@
 import React, { createElement } from 'react'
-import getMatrix, { shapes, Shapes, Options, eyeBalls, eyeFrames, EyeBalls, EyeFrames } from '@qr-x/core'
+import getMatrix, { shapes, Shapes, Options, eyeBalls, eyeFrames, EyeBalls, EyeFrames, Color } from '@qr-x/core'
 
-type Props = Options & { shape?: Shapes; multiplePahts?: boolean; eyeBall?: EyeBalls; eyeFrame?: EyeFrames }
+type Props = Options & {
+  shape?: Shapes
+  multiplePahts?: boolean
+  eyeBall?: EyeBalls
+  eyeFrame?: EyeFrames
+  foregroundColor?: Color
+}
 
-export default function QRX({ shape = 'square', eyeBall = 'square', eyeFrame = 'square', multiplePahts, ...options }: Props) {
+export default function QRX({
+  shape = 'square',
+  eyeBall = 'square',
+  eyeFrame = 'square',
+  multiplePahts,
+  foregroundColor = '#000',
+  ...options
+}: Props) {
   const matrix = getMatrix(options)
   const { tag, props } = shapes[shape]
   const eyeballProps = eyeBalls[eyeBall].props
   const eyeframeProps = eyeFrames[eyeFrame].props
 
   return (
-    <svg xmlns='http://www.w3.org/2000/svg' viewBox={`0 0 ${matrix.length} ${matrix.length}`} width='100%' height='100%'>
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox={`0 0 ${matrix.length} ${matrix.length}`}
+      width='100%'
+      height='100%'
+      style={{
+        padding: 10,
+      }}
+    >
       {/* Safari won't render SVGs without width and height */}
       {multiplePahts ? (
-        matrix.map((row, i) => row.map(({ isON }, j) => createElement(tag, { ...props(i, j), fill: isON ? '#000' : '#fff' })))
+        matrix.map((row, i) =>
+          row.map(({ isON }, j) => createElement(tag, { ...props(i, j), fill: isON ? foregroundColor : 'transparent' })),
+        )
       ) : (
         <path
+          fill={foregroundColor}
           d={`
           ${matrix
             .map((row, i) =>


### PR DESCRIPTION
Added this Color Type at the path.

packages/core/dist/index.d.ts

type RGB = `rgb(${number}, ${number}, ${number})`
type RGBA = `rgba(${number}, ${number}, ${number}, ${number})`
type HSL = `hsl(${number}%, ${number}%, ${number}%)`
type HEX = `#${string}`

export type Color = RGB | RGBA | HSL | HEX