### PR TITLE
Added excavation ability to skip rendering modules covered by brand image and brand component

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -13,8 +13,8 @@ type Gradient = ({ type?: 'linear'; rotate?: number } | { type: 'radial'; rotate
 }
 
 export type Excavate = {
-  width:number | string
-  height:number | string
+  width:number
+  height:number
 }
 
 export type Options = {
@@ -115,8 +115,8 @@ function excavateModules(modules:boolean[][], size:number, excavate:Excavate) {
   const scale = length / size;
 
   const { width, height } = excavate; // brand area
-  const w = convertToPixels(width) * scale;
-  const h = convertToPixels(height) * scale;
+  const w = width * scale;
+  const h = height * scale;
   const x = length / 2 - w / 2;
   const y = length / 2 - h / 2;
 
@@ -139,20 +139,3 @@ function excavateModules(modules:boolean[][], size:number, excavate:Excavate) {
     });
   });
 }
-
-const convertToPixels = (value:number | string):number => {
-  if (!isNaN(+value)) {
-    return value as number;
-  }
-
-  const temp = document.createElement('div');
-  temp.style.position = 'absolute';
-  temp.style.visibility = 'hidden';
-  temp.style.width = value.toString();
-  document.body.appendChild(temp);
-
-  const pixels = temp.offsetWidth;
-
-  document.body.removeChild(temp);
-  return pixels;
-};

--- a/packages/react/index.tsx
+++ b/packages/react/index.tsx
@@ -17,9 +17,9 @@ function useViewBox() {
   return { ref, size, viewBox: size ? `0 0 ${size.width} ${size.height}` : '' }
 }
 
-export default function QRX({ data, level, brand, shapes, gradient, fillImage, ...rest }: Props) {
+export default function QRX({ data, level, brand, shapes, gradient, fillImage, excavate, ...rest }: Props) {
   const { ref, size, viewBox } = useViewBox()
-  const { id, path, cords, length, $gradient } = getSVGData({ data, level, shapes, gradient })
+  const { id, path, cords, length, $gradient } = getSVGData({ data, level, shapes, gradient, excavate, size:size?.width })
 
   return (
     <svg ref={ref} width='100%' {...rest} viewBox={`0 0 ${length} ${length}`}>


### PR DESCRIPTION
# Excavation feature
**Excavation** is an ability to skip rendering modules at a specific area. For instance, if we show brand image or brand component at the center, some modules are covered by that. Therefore, if we want to add some spacing between modules and brand, we can add **excavation** instead of **padding** so that we may remove the exact modules unlike padding which may require manual adjustment and may not be responsive to the size of QR.  

## Added excavation ability in the following modules
 - [x] core
 - [x] react
 - [ ] react native
 - [ ] solid
 - [ ] svelte
 - [ ] vanilla
 - [ ] vue
 
 ## Example
 ```javascript
 <QRX
     excavate={{ width:80, height:80 }}
     data={data}
     // brand or image
    } />
 ```
 
<img width="298" alt="Screenshot 2024-10-10 at 1 24 27 AM" src="https://github.com/user-attachments/assets/4a5fd254-c5e4-4953-978b-72146048a7f4">

